### PR TITLE
fix: update input handling logic to use a lambda for selection

### DIFF
--- a/src/PanasonicProjectorController.cs
+++ b/src/PanasonicProjectorController.cs
@@ -539,7 +539,7 @@ namespace PanasonicProjectorEpi
                     {
                     if (allInputs.TryGetValue(activeInput.Key, out var input))
                         {
-                        Inputs.Items.Add(input.Key, new PanasonicInput(input.Value.Key.ToString(), activeInput.Value, this, input.Value.Select()));
+                        Inputs.Items.Add(input.Key, new PanasonicInput(input.Value.Key.ToString(), activeInput.Value, this, () => input.Value.Select()));
                         }
                     else
                         {


### PR DESCRIPTION
This pull request makes a small but important change to the `SetupInputPorts` method in the `src/PanasonicProjectorController.cs` file. The change ensures that the `Select` method is passed as a lambda function instead of being invoked directly during the initialization of `PanasonicInput`.

Key change:

* [`src/PanasonicProjectorController.cs`](diffhunk://#diff-249d99702f3b59e679c556acb155904cfff8c81d633c3c45a9ccb8c59d569e81L542-R542): Modified the `SetupInputPorts` method to wrap the `input.Value.Select()` call in a lambda function (`() => input.Value.Select()`). This ensures that the `Select` method is not executed immediately but is deferred until invoked.