### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,21 @@ This plugin is designed to work with Panasonic projectors controlled via TCP/IP 
     },
     "id": "01",
     "warmupTimeInSeconds":1,
-    "cooldownTimeInSeconds":2
+    "cooldownTimeInSeconds":2,
+        "activeInputs": [
+            {
+              "key": "HDMI1",
+              "name": "HDMI 1"
+            },
+            {
+              "key": "HDMI2",
+              "name": "HDMI 2"
+            },
+            {
+              "key": "DVI",
+              "name": "DVI"
+            }
+          ]
   }
 }
 ```
@@ -41,6 +55,8 @@ This plugin is designed to work with Panasonic projectors controlled via TCP/IP 
 
 - Valid `id` values are ZZ, 01 to 64, and 0A to 0Z
 - `warmupTimeInSeconds` and `cooldownTimeInSeconds` are optional. If they are omitted, the plugin will default to 1 second and 2 seconds respectively.
+- `activeInputs` are optional. If they are omitted, the plugin will include all inputs with their default names by default.
+- Valid `activeInputs` input keys are:  Computer1, Computer2, Video, S-Video, DVI, HDMI1, HDMI2, SDI and DigitalLink.
 
 ### TCP/IP
 
@@ -62,7 +78,23 @@ This plugin is designed to work with Panasonic projectors controlled via TCP/IP 
         "autoReconnectIntervalMs": 5000,
         "bufferSize": 32768
       }
-    }
+    },
+    "warmupTimeInSeconds":1,
+    "cooldownTimeInSeconds":2,
+    "activeInputs": [
+            {
+              "key": "HDMI1",
+              "name": "HDMI 1"
+            },
+            {
+              "key": "HDMI2",
+              "name": "HDMI 2"
+            },
+            {
+              "key": "DVI",
+              "name": "DVI"
+            }
+          ]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This plugin is designed to work with Panasonic projectors controlled via TCP/IP 
               "name": "DVI"
             }
           ]
+    ]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ This plugin is designed to work with Panasonic projectors controlled via TCP/IP 
     "id": "01",
     "warmupTimeInSeconds":1,
     "cooldownTimeInSeconds":2,
-        "activeInputs": [
-            {
-              "key": "HDMI1",
-              "name": "HDMI 1"
-            },
-            {
-              "key": "HDMI2",
-              "name": "HDMI 2"
-            },
-            {
-              "key": "DVI",
-              "name": "DVI"
-            }
-          ]
+    "activeInputs": [
+        {
+          "key": "HDMI1",
+          "name": "HDMI 1"
+        },
+        {
+          "key": "HDMI2",
+          "name": "HDMI 2"
+        },
+        {
+          "key": "DVI",
+          "name": "DVI"
+        }
+    ]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ This plugin is designed to work with Panasonic projectors controlled via TCP/IP 
 
 - Valid `id` values are ZZ, 01 to 64, and 0A to 0Z
 - `warmupTimeInSeconds` and `cooldownTimeInSeconds` are optional. If they are omitted, the plugin will default to 1 second and 2 seconds respectively.
-- `activeInputs` are optional. If they are omitted, the plugin will include all inputs with their default names by default.
-- Valid `activeInputs` input keys are:  Computer1, Computer2, Video, S-Video, DVI, HDMI1, HDMI2, SDI and DigitalLink.
 
 ### TCP/IP
 
@@ -64,23 +62,7 @@ This plugin is designed to work with Panasonic projectors controlled via TCP/IP 
         "autoReconnectIntervalMs": 5000,
         "bufferSize": 32768
       }
-    },
-    "warmupTimeInSeconds":1,
-          "cooldownTimeInSeconds":2,
-          "activeInputs": [
-            {
-              "key": "HDMI1",
-              "name": "HDMI 1"
-            },
-            {
-              "key": "HDMI2",
-              "name": "HDMI 2"
-            },
-            {
-              "key": "DVI",
-              "name": "DVI"
-            }
-          ]
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ This plugin is designed to work with Panasonic projectors controlled via TCP/IP 
 
 - Valid `id` values are ZZ, 01 to 64, and 0A to 0Z
 - `warmupTimeInSeconds` and `cooldownTimeInSeconds` are optional. If they are omitted, the plugin will default to 1 second and 2 seconds respectively.
+- `activeInputs` are optional. If they are omitted, the plugin will include all inputs with their default names by default.
+- Valid `activeInputs` input keys are:  Computer1, Computer2, Video, S-Video, DVI, HDMI1, HDMI2, SDI and DigitalLink.
 
 ### TCP/IP
 
@@ -62,7 +64,23 @@ This plugin is designed to work with Panasonic projectors controlled via TCP/IP 
         "autoReconnectIntervalMs": 5000,
         "bufferSize": 32768
       }
-    }
+    },
+    "warmupTimeInSeconds":1,
+          "cooldownTimeInSeconds":2,
+          "activeInputs": [
+            {
+              "key": "HDMI1",
+              "name": "HDMI 1"
+            },
+            {
+              "key": "HDMI2",
+              "name": "HDMI 2"
+            },
+            {
+              "key": "DVI",
+              "name": "DVI"
+            }
+          ]
   }
 }
 ```


### PR DESCRIPTION
This pull request updates the `README.md` file to include new configuration options for Panasonic projector plugins. The changes primarily involve adding support for specifying active input sources and clarifying their usage.

### Updates to configuration options:

* Added an `activeInputs` array to the configuration, allowing users to specify active input sources, each with a `key` and `name`. This is optional, and if omitted, all inputs will be included with default names. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R49)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81-R97)`)

* Documented valid `activeInputs` keys (`Computer1`, `Computer2`, `Video`, `S-Video`, `DVI`, `HDMI1`, `HDMI2`, `SDI`, `DigitalLink`) and clarified their optional nature in the plugin configuration. (`[README.mdR58-R59](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R59)`)